### PR TITLE
Small improvements to issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-This issue tracker is intended only for Silverblue specific issues. We would like to ask you to try to reproduce the issue on a relevant Fedora Workstation release. If you will be able to reproduce there, then please report it in Red Hat Bugzilla or in upstream (preferred for GNOME projects) and not in this issue tracker.
+This issue tracker is intended only for Silverblue specific issues. We would like to ask you to try to reproduce the issue on a relevant Fedora Workstation release. If you will be able to reproduce there, then please report it in [Red Hat Bugzilla](https://bugzilla.redhat.com/) (see [How to file a bug](https://docs.fedoraproject.org/en-US/quick-docs/howto-file-a-bug/)) or in upstream (preferred for GNOME projects) and not in this issue tracker.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: "[BUG] "
-labels: ''
+about: Report an issue with Fedora Silverblue
+title: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-title: "[RFE] "
-labels: ''
+about: Request a new feature in Fedora Silverblue
+title: ""
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-package.md
+++ b/.github/ISSUE_TEMPLATE/new-package.md
@@ -1,0 +1,32 @@
+---
+name: Request a new package
+about: Ask for a new package to be added to Fedora Silverblue
+title: 'New Package Request: <package name>'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+Please try to answer the following questions about the package you are requesting:
+
+1. Is the package installed by default in Fedora Wokrstation? If it is not, we will ask you to [open an issue in the issue tracker](https://pagure.io/fedora-workstation/issues) for the [Fedora Workstation Working Group](https://docs.fedoraproject.org/en-US/workstation-working-group/).
+
+2. What, if any, are the additional dependencies on the package? What is the output of this command on a system without overides or locally installed packages:
+   ```
+   $ rpm-ostree install --dry-run <package>
+   ```
+
+3. What is the size of the package and its dependencies?
+   ```
+   rpm -qi <package>
+   ```
+
+4. What problem are you trying to solve with this package? Or what functionality does the package provide?
+
+5. Can the software provided by the package be run from a container? Explain why or why not.
+
+6. Can the tool(s) provided by the package be helpful in debugging container runtime issues?
+
+7. Can the tool(s) provided by the package be helpful in debugging networking issues?
+
+8. Is it possible to layer the package locally via `rpm-ostree install <package>`? Explain why or why not.


### PR DESCRIPTION
GitHub Issue Templates: Use labels instead of prefix

Using labels makes it easier to filter issue in the GitHub UI.

---

GitHub Issue Templates: Add links to Bugzilla

---

GitHub Issue Templates: Add New Package template